### PR TITLE
Including cstdlib.

### DIFF
--- a/gx.hh
+++ b/gx.hh
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <vector>
 #include <cstring>
+#include <cstdlib>
 
 
 namespace gx {


### PR DESCRIPTION
Resolved: abort is not a member of std
Tested: gcc 9.3.0 x86_64-linux-gnu